### PR TITLE
Preserve the file address when a line number isn't known.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -475,7 +475,7 @@ impl Fixer {
     /// `bar.o` is within the archive `libfoo.a`. If so, return the archive
     /// name.
     fn is_within_archive(file_name: &str) -> Option<&str> {
-        if let (Some(index), true) = (file_name.find(".a("), file_name.ends_with(")")) {
+        if let (Some(index), true) = (file_name.find(".a("), file_name.ends_with(')')) {
             let ar_file_name = &file_name[..index + 2];
             Some(ar_file_name)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,14 +578,19 @@ impl Fixer {
                 )
             } else {
                 // We have the filename from the debug info, but no line number.
-                format!("{} ({})", func_info.demangled_name(), file_name)
+                format!(
+                    "{} ({} +0x{:x})",
+                    func_info.demangled_name(),
+                    file_name,
+                    address
+                )
             }
         } else {
             // We have nothing from the symbols or debug info. Use the file name
             // from original input, which is probably "???". The end result is the
             // same as the original line, but with the address removed and slightly
             // different formatting.
-            format!("{} ({})", func_name, file_name)
+            format!("{} ({} +0x{:x})", func_name, file_name, address)
         };
 
         if let JsonEscaping::Yes = self.json_escaping {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -67,8 +67,9 @@ fn test_linux() {
     // Test various addresses outside `main`, `f`, and `g`.
     let mut outside = |addr| {
         let line = format!("#00: ???[tests/example-linux +0x{:x}]", addr);
-        let line = fixer.fix(line);
-        assert_eq!(format!("#00: ??? (tests/example-linux)"), line);
+        let line_actual = fixer.fix(line);
+        let line_expected = format!("#00: ??? (tests/example-linux +0x{:x})", addr);
+        assert_eq!(line_expected, line_actual);
     };
     outside(0x0); // A very low address.
     outside(0x999); // Well before the start of main.
@@ -148,8 +149,9 @@ fn test_windows() {
     // `example-windows.pdb` directly.
     let mut outside = |addr| {
         let line = format!("#00: foobar[tests/example-windows.pdb +0x{:x}]", addr);
-        let line = fixer.fix(line);
-        assert_eq!(format!("#00: foobar (tests/example-windows.pdb)"), line);
+        let line_actual = fixer.fix(line);
+        let line_expected = format!("#00: foobar (tests/example-windows.pdb +0x{:x})", addr);
+        assert_eq!(line_expected, line_actual);
     };
     outside(0x0); // A very low address.
     outside(0x999); // Well before the start of main.
@@ -232,13 +234,14 @@ fn test_mac() {
     // Test addresses from all the object files that `mac-multi` references.
     let mut func = |name, addr, full_path, locn| {
         let line = format!("#00: ???[tests/mac-multi +0x{:x}]", addr);
-        let line = fixer.fix(line);
+        let line_actual = fixer.fix(line);
         let path = if full_path {
             "/Users/njn/moz/fix-stacks/tests/"
         } else {
             "tests/"
         };
-        assert_eq!(line, format!("#00: {} ({}{})", name, path, locn));
+        let line_expected = format!("#00: {} ({}{})", name, path, locn);
+        assert_eq!(line_expected, line_actual);
     };
 
     func("main", 0xd70, true, "mac-normal.c:17");
@@ -252,7 +255,7 @@ fn test_mac() {
     func("lib1_A", 0xe95, true, "mac-lib1.c:15");
     // This should be `duplicate` in `mac-lib1.c`. It's wrong due to the
     // archive suffix stripping mentioned above.
-    func("???", 0xeaa, false, "mac-multi");
+    func("???", 0xeaa, false, "mac-multi +0xeaa");
 
     func("lib2_B", 0xedc, true, "mac-lib2.c:20");
     func("lib2_A", 0xf1e, true, "mac-lib2.c:16");


### PR DESCRIPTION
This makes the output of `fix-stacks` more closely match the output of (a) `fix_macosx_stack.py`, and (b) no fixer. This in turn makes it easier to swap in `fix-stacks` for use with DMD and pass the existing tests.
