### PR TITLE
Add support for Breakpad symbols.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ is changed to something like this in the output:
 Lines that do not match the special stack frame format are passed through
 unchanged.
 
-Because the stack frames produced by `MozFormatCodeAddress()` refer to build
-files (such as libxul), `fix-stacks` must run on the same machine that produced
-the stack frames and the build files. Furthermore, the build files must not
-have changed since the stack frames were produced. Otherwise, source locations
-in the output may be missing or incorrect.
+By default, `fix-stacks` uses native debug info present in binary files. In
+this case, because the stack frames produced by `MozFormatCodeAddress()` refer
+to build files (such as libxul), `fix-stacks` must run on the same machine that
+produced the stack frames and the build files. Furthermore, the build files
+must not have changed since the stack frames were produced. Otherwise, source
+locations in the output may be missing or incorrect.
+
+Alternatively, you can use the `-b` option to tell `fix-stacks` to read
+Breakpad symbol files, as packaged by Firefox. In this case, the processed
+output will contain square brackets instead of parentheses, to make it
+detectable from the output that breakpad symbols were used.
 
 `fix-stacks` works on Linux, Windows, and Mac.
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ must not have changed since the stack frames were produced. Otherwise, source
 locations in the output may be missing or incorrect.
 
 Alternatively, you can use the `-b` option to tell `fix-stacks` to read
-Breakpad symbol files, as packaged by Firefox. In this case, the processed
-output will contain square brackets instead of parentheses, to make it
-detectable from the output that breakpad symbols were used.
+Breakpad symbol files, as packaged by Firefox. The argument must contain two
+paths, separated by a comma: the first path points to the Breakpad symbols
+directory, the second path points to the `fileid` executable in the Firefox
+objdir. In this case, the processed output will contain square brackets instead
+of parentheses, to make it detectable from the output that breakpad symbols
+were used. 
 
 `fix-stacks` works on Linux, Windows, and Mac.
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@ use crate::*;
 
 #[test]
 fn test_linux() {
-    // The debug info within `example-linux` is as follows. (See
+    // The native debug info within `example-linux` is as follows. (See
     // `tests/README.md` for details on how these lines were generated.)
     //
     //   FUNC 0x1130 size=40 func=main
@@ -31,7 +31,7 @@ fn test_linux() {
     //   LINE 0x11cd line=13 file=/home/njn/moz/fix-stacks/tests/example.c
     //   LINE 0x11db line=14 file=/home/njn/moz/fix-stacks/tests/example.c
 
-    let mut fixer = Fixer::new(JsonMode::No);
+    let mut fixer = Fixer::new(JsonMode::No, None);
 
     // Test various addresses.
     let mut func = |name, addr, linenum| {
@@ -62,13 +62,13 @@ fn test_linux() {
     func("g", 0x11de, 14);
 
     // Try a new Fixer.
-    fixer = Fixer::new(JsonMode::No);
+    fixer = Fixer::new(JsonMode::No, None);
 
     // Test various addresses outside `main`, `f`, and `g`.
     let mut outside = |addr| {
         let line = format!("#00: ???[tests/example-linux +0x{:x}]", addr);
         let line_actual = fixer.fix(line);
-        let line_expected = format!("#00: ??? (tests/example-linux +0x{:x})", addr);
+        let line_expected = format!("#00: ??? (tests/example-linux + 0x{:x})", addr);
         assert_eq!(line_expected, line_actual);
     };
     outside(0x0); // A very low address.
@@ -80,7 +80,7 @@ fn test_linux() {
 
 #[test]
 fn test_windows() {
-    // The debug info within `example-windows.pdb` is as follows. (See
+    // The native debug info within `example-windows.pdb` is as follows. (See
     // `tests/README.md` for details on how these lines were generated.)
     //
     //   FUNC 0x6bc0 size=39 func=main
@@ -110,7 +110,7 @@ fn test_windows() {
     // outputs contains backwards slashes, though, because that is what is used
     // within the debug info.
 
-    let mut fixer = Fixer::new(JsonMode::Yes);
+    let mut fixer = Fixer::new(JsonMode::Yes, None);
 
     // Test various addresses using `example-windows`, which redirects to
     // `example-windows.pdb`.
@@ -143,14 +143,14 @@ fn test_windows() {
     func("g", 0x6c63, 14);
 
     // Try a new Fixer, without JSON mode.
-    fixer = Fixer::new(JsonMode::No);
+    fixer = Fixer::new(JsonMode::No, None);
 
     // Test various addresses outside `main`, `f`, and `g`, using
     // `example-windows.pdb` directly.
     let mut outside = |addr| {
         let line = format!("#00: foobar[tests/example-windows.pdb +0x{:x}]", addr);
         let line_actual = fixer.fix(line);
-        let line_expected = format!("#00: foobar (tests/example-windows.pdb +0x{:x})", addr);
+        let line_expected = format!("#00: foobar (tests/example-windows.pdb + 0x{:x})", addr);
         assert_eq!(line_expected, line_actual);
     };
     outside(0x0); // A very low address.
@@ -162,8 +162,8 @@ fn test_windows() {
 
 #[test]
 fn test_mac() {
-    // The debug info within `mac-multi` is as follows. (See `tests/README.md`
-    // for details on how these lines were generated.)
+    // The native debug info within `mac-multi` is as follows. (See
+    // `tests/README.md` for details on how these lines were generated.)
     //
     //   FUNC 0xd70 size=54 func=main
     //   LINE 0xd70 line=17 file=/Users/njn/moz/fix-stacks/tests/mac-normal.c
@@ -229,7 +229,7 @@ fn test_mac() {
     //   LINE 0xf38 line=10 file=/Users/njn/moz/fix-stacks/tests/mac-lib2.c
     //   LINE 0xf49 line=11 file=/Users/njn/moz/fix-stacks/tests/mac-lib2.c
 
-    let mut fixer = Fixer::new(JsonMode::No);
+    let mut fixer = Fixer::new(JsonMode::No, None);
 
     // Test addresses from all the object files that `mac-multi` references.
     let mut func = |name, addr, full_path, locn| {
@@ -255,7 +255,7 @@ fn test_mac() {
     func("lib1_A", 0xe95, true, "mac-lib1.c:15");
     // This should be `duplicate` in `mac-lib1.c`. It's wrong due to the
     // archive suffix stripping mentioned above.
-    func("???", 0xeaa, false, "mac-multi +0xeaa");
+    func("???", 0xeaa, false, "mac-multi + 0xeaa");
 
     func("lib2_B", 0xedc, true, "mac-lib2.c:20");
     func("lib2_A", 0xf1e, true, "mac-lib2.c:16");
@@ -265,8 +265,78 @@ fn test_mac() {
 }
 
 #[test]
+fn test_breakpad() {
+    // The breakpad symbols debug info within `example-linux` is as follows.
+    // (See `tests/README.md` for details on how these lines were generated.)
+    //
+    // FUNC 0x1130 size=40 func=main
+    // LINE 0x1130 line=24 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x113f line=25 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1146 line=26 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x114f line=27 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1152 line=27 file=/home/njn/moz/fix-stacks/tests/example.c
+    //
+    // FUNC 0x1160 size=69 func=f
+    // LINE 0x1160 line=16 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x116c line=17 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1170 line=17 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1177 line=18 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x117b line=18 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1180 line=19 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1184 line=19 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x118b line=20 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x118f line=20 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1194 line=21 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x1198 line=21 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x119f line=22 file=/home/njn/moz/fix-stacks/tests/example.c
+    //
+    // FUNC 0x11b0 size=49 func=g
+    // LINE 0x11b0 line=11 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x11bc line=12 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x11cd line=13 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x11d1 line=13 file=/home/njn/moz/fix-stacks/tests/example.c
+    // LINE 0x11db line=14 file=/home/njn/moz/fix-stacks/tests/example.c
+
+    let mut fixer = Fixer::new(JsonMode::No, Some("tests/bpsyms".to_string()));
+
+    // Test various addresses.
+    let mut func = |name, addr, linenum| {
+        let line = format!("#00: ???[tests/example-linux +0x{:x}]", addr);
+        let line = fixer.fix(line);
+        assert_eq!(
+            line,
+            format!(
+                "#00: {} [/home/njn/moz/fix-stacks/tests/example.c:{}]",
+                name, linenum
+            )
+        );
+    };
+    func("main", 0x1130, 24);
+    func("main", 0x113f, 25);
+    func("main", 0x1146, 26);
+    func("main", 0x1157, 27);
+    func("f", 0x1160, 16);
+    func("f", 0x1180, 19);
+    func("g", 0x11bc, 12);
+    func("g", 0x11de, 14);
+
+    // Test various addresses outside `main`, `f`, and `g`.
+    let mut outside = |addr| {
+        let line = format!("#00: ???[tests/example-linux +0x{:x}]", addr);
+        let line_actual = fixer.fix(line);
+        let line_expected = format!("#00: ??? [tests/example-linux + 0x{:x}]", addr);
+        assert_eq!(line_expected, line_actual);
+    };
+    outside(0x0); // A very low address.
+    outside(0x999); // Well before the start of main.
+    outside(0x112f); // One byte before the start of `main`.
+    outside(0x1158); // One byte past the end of `main`.
+    outside(0xfffffff); // A very high address.
+}
+
+#[test]
 fn test_regex() {
-    let mut fixer = Fixer::new(JsonMode::No);
+    let mut fixer = Fixer::new(JsonMode::No, None);
 
     // Test various different unchanged line forms, that don't match the regex.
     let mut unchanged = |line: &str| {
@@ -301,7 +371,7 @@ fn test_regex() {
 
 #[test]
 fn test_files() {
-    let mut fixer = Fixer::new(JsonMode::Yes);
+    let mut fixer = Fixer::new(JsonMode::Yes, None);
 
     // Test various different file errors. An error message is also printed to
     // stderr for each one, but we don't test for that.
@@ -312,16 +382,13 @@ fn test_files() {
     // No such file.
     file_error(
         "#00: ???[tests/no-such-file +0x0]",
-        "#00: ??? (tests/no-such-file +0x0)",
+        "#00: ??? (tests/no-such-file + 0x0)",
     );
     // No such file, with backslashes (which tests JSON escaping).
     file_error(
         "#00: ???[tests\\no-such-dir\\\\no-such-file +0x0]",
-        "#00: ??? (tests\\no-such-dir\\\\no-such-file +0x0)",
+        "#00: ??? (tests\\no-such-dir\\\\no-such-file + 0x0)",
     );
     // File exists, but has the wrong format.
-    file_error(
-        "#00: ???[src/main.rs +0x0]",
-        "#00: ??? (src/main.rs +0x0)",
-    );
+    file_error("#00: ???[src/main.rs +0x0]", "#00: ??? (src/main.rs + 0x0)");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -297,7 +297,16 @@ fn test_breakpad() {
     // LINE 0x11d1 line=13 file=/home/njn/moz/fix-stacks/tests/example.c
     // LINE 0x11db line=14 file=/home/njn/moz/fix-stacks/tests/example.c
 
-    let mut fixer = Fixer::new(JsonMode::No, Some("tests/bpsyms".to_string()));
+    // We can use "" for `fileid_exe` because that field is only used for
+    // binaries with multiple Breakpad symbol dirs, which this test doesn't
+    // have.
+    let mut fixer = Fixer::new(
+        JsonMode::No,
+        Some(BreakpadInfo {
+            syms_dir: "tests/bpsyms".to_string(),
+            fileid_exe: "".to_string(),
+        }),
+    );
 
     // Test various addresses.
     let mut func = |name, addr, linenum| {

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,6 +73,19 @@ relative paths such as `tests///////////////////////////mac-normal.c`. (The use
 of many redundant forward slashes is a hack to keep the path the same length,
 which avoids the need for more complex changes to that file.)
 
+### Breakpad symbols
+
+`bpsyms/` was produced on an Ubuntu 19.10 box by `dump_syms` (from a
+development build of Firefox), with these commands:
+```
+# 123456781234567812345678123456789 is a fake UUID whose exact value doesn't
+# matter.
+DIR="bpsyms/example-linux/123456781234567812345678123456789/"
+mkdir $DIR
+# $OBJDIR is the object directory of the Firefox build.
+$OBJDIR/dist/host/bin/dump_syms example-linux > $DIR/example-linux.sym
+```
+
 ## Obtaining the debug info
 
 The unit tests refer to specific addresses within the generated binaries. These

--- a/tests/bpsyms/example-linux/123456781234567812345678123456789/example-linux.sym
+++ b/tests/bpsyms/example-linux/123456781234567812345678123456789/example-linux.sym
@@ -1,0 +1,70 @@
+MODULE Linux x86_64 BE4E976C325246EE9D6B7847A670B2A90 example-linux
+INFO CODE_ID 6C974EBE5232EE469D6B7847A670B2A956F8AEDE
+FILE 0 /home/njn/moz/fix-stacks/tests/example.c
+FUNC 1130 28 0 main
+1130 f 24 0
+113f 7 25 0
+1146 9 26 0
+114f 3 27 0
+1152 6 27 0
+FUNC 1160 45 0 f
+1160 c 16 0
+116c 4 17 0
+1170 7 17 0
+1177 4 18 0
+117b 5 18 0
+1180 4 19 0
+1184 7 19 0
+118b 4 20 0
+118f 5 20 0
+1194 4 21 0
+1198 7 21 0
+119f 6 22 0
+FUNC 11b0 31 0 g
+11b0 c 11 0
+11bc 11 12 0
+11cd 4 13 0
+11d1 a 13 0
+11db 6 14 0
+PUBLIC 1000 0 _init
+PUBLIC 1040 0 _start
+PUBLIC 1070 0 _dl_relocate_static_pie
+PUBLIC 1080 0 deregister_tm_clones
+PUBLIC 10b0 0 register_tm_clones
+PUBLIC 10f0 0 __do_global_dtors_aux
+PUBLIC 1120 0 frame_dummy
+PUBLIC 11f0 0 __libc_csu_init
+PUBLIC 1250 0 __libc_csu_fini
+PUBLIC 1254 0 _fini
+STACK CFI INIT 1020 20 .cfa: $rsp 16 + .ra: .cfa -8 + ^
+STACK CFI 1026 .cfa: $rsp 24 +
+STACK CFI INIT 1040 2b .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1070 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1130 28 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 1131 $rbp: .cfa -16 + ^ .cfa: $rsp 16 +
+STACK CFI 1134 .cfa: $rbp 16 +
+STACK CFI 1157 .cfa: $rsp 8 +
+STACK CFI INIT 1160 45 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 1161 $rbp: .cfa -16 + ^ .cfa: $rsp 16 +
+STACK CFI 1164 .cfa: $rbp 16 +
+STACK CFI 11a4 .cfa: $rsp 8 +
+STACK CFI INIT 11b0 31 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 11b1 $rbp: .cfa -16 + ^ .cfa: $rsp 16 +
+STACK CFI 11b4 .cfa: $rbp 16 +
+STACK CFI 11e0 .cfa: $rsp 8 +
+STACK CFI INIT 11f0 5d .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 11f2 $r15: .cfa -16 + ^ .cfa: $rsp 16 +
+STACK CFI 11f7 $r14: .cfa -24 + ^ .cfa: $rsp 24 +
+STACK CFI 11fc $r13: .cfa -32 + ^ .cfa: $rsp 32 +
+STACK CFI 1201 $r12: .cfa -40 + ^ .cfa: $rsp 40 +
+STACK CFI 1209 $rbp: .cfa -48 + ^ .cfa: $rsp 48 +
+STACK CFI 1211 $rbx: .cfa -56 + ^ .cfa: $rsp 56 +
+STACK CFI 1218 .cfa: $rsp 64 +
+STACK CFI 1242 .cfa: $rsp 56 +
+STACK CFI 1243 .cfa: $rsp 48 +
+STACK CFI 1244 .cfa: $rsp 40 +
+STACK CFI 1246 .cfa: $rsp 32 +
+STACK CFI 1248 .cfa: $rsp 24 +
+STACK CFI 124a .cfa: $rsp 16 +
+STACK CFI 124c .cfa: $rsp 8 +
+STACK CFI INIT 1250 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^


### PR DESCRIPTION
This involves:
- A new option: `-b`/`--breakpad`, for specifying the Breakpad symbols
  directory.
- Code for finding particular `.sym` files within that directory.
- Adding a space before the address in output lines, so they don't match
  the input regexp and thus won't be double processed.
- A new test, `test_breakpad`.

r? @gabrielesvelto