### PR TITLE
Build with LTO.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = "1.0"
 symbolic-common = "7.1.1"
 symbolic-debuginfo = "7.1.1"
 symbolic-demangle = "7.1.1"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
It's a significant speed win on Mac and Windows. (I saw `dmd.py` runs
drop from about 40 seconds to about 30 seconds.)