### PR TITLE
Remove junk from Breakpad filenames.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,10 @@ mkdir $DIR
 $OBJDIR/dist/host/bin/dump_syms example-linux > $DIR/example-linux.sym
 ```
 
+`example-linux.sym` was then edited to change the `FILE` line mentioning
+`example.c` to be prefixed with a Mercurial repository and suffixed with a
+revision ID, in order to test the removal of this Firefox Breakpad junk.
+
 `bpsyms/example-windows.pdb/` was produced on Windows 10 laptop by
 `dump_syms.exe`, with these commands within `tests/`:
 ```

--- a/tests/bpsyms/example-linux/123456781234567812345678123456789/example-linux.sym
+++ b/tests/bpsyms/example-linux/123456781234567812345678123456789/example-linux.sym
@@ -1,6 +1,6 @@
 MODULE Linux x86_64 BE4E976C325246EE9D6B7847A670B2A90 example-linux
 INFO CODE_ID 6C974EBE5232EE469D6B7847A670B2A956F8AEDE
-FILE 0 /home/njn/moz/fix-stacks/tests/example.c
+FILE 0 hg:hg.mozilla.org/integration/autoland:/home/njn/moz/fix-stacks/tests/example.c:94d31f914f29e72dd81a8880100d12f67e48a5b0
 FUNC 1130 28 0 main
 1130 f 24 0
 113f 7 25 0


### PR DESCRIPTION
This changes annoying filenames like this:
```
hg:hg.mozilla.org/integration/autoland:caps/BasePrincipal.cpp:04c31e994f29e72dd81a7340100d12f67e48a5b4
```
which are an artifact of how Firefox constructs its Breakpad files, to this:
```
caps/BasePrincipal.cpp
```
This will fix https://bugzilla.mozilla.org/show_bug.cgi?id=1632928.

r? @gabrielesvelto