### PR TITLE
Use `anyhow` for error handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fix-stacks"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -668,6 +675,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
+failure = "0.1.5" # Keep this in sync with what symbolic-debuginfo is using.
 fxhash = "0.2.1"
 goblin = "0.2.1" # Keep this in sync with what symbolic-debuginfo is using.
 regex = "1.3.5"
 serde_json = "1.0"
-
 symbolic-common = "7.1.1"
 symbolic-debuginfo = "7.1.1"
 symbolic-demangle = "7.1.1"


### PR DESCRIPTION
Because it's more idiomatic, removes the need for `FixErr`, and it gives
useful chains of error causes. For example, where we use to print this:

> fix-stacks error: failed to read `inline-gcc`

We now print this:

> fix-stacks: error: failed to read `inline-gcc`
> fix-stacks: No such file or directory (os error 2)

r? @gabrielesvelto 