### PR TITLE
Disable test_mac because it's failing.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -161,6 +161,7 @@ fn test_windows() {
 }
 
 #[test]
+#[ignore] // https://github.com/mozilla/fix-stacks/issues/45
 fn test_mac() {
     // The native debug info within `mac-multi` is as follows. (See
     // `tests/README.md` for details on how these lines were generated.)


### PR DESCRIPTION
See #45.